### PR TITLE
Update quicktime to launch as subprocess

### DIFF
--- a/pipeline_plugins/resource/hook/quicktime.py
+++ b/pipeline_plugins/resource/hook/quicktime.py
@@ -136,9 +136,9 @@ class QuickTimeAction(object):
 
                 for asset in task.getAssets(assetTypes=["mov"]):
                     for version in asset.getVersions():
-                        version = str(version.getVersion()).zfill(3)
+                        padded_version = str(version.getVersion()).zfill(3)
                         for component in version.getComponents():
-                            label = "v" + version
+                            label = "v" + padded_version
                             label += " - " + asset.getType().getName()
                             label += " - " + component.getName()
                             data.append({


### PR DESCRIPTION
Currently, the quicktime launcher does not open files correctly due to the id of the component being supplied to the launcher.

This updates to launch quicktime as a subprocess, as with the djvviewer launcher, using the component filepath as an argument.