### PR TITLE
Correct variable name when looking up task components

### DIFF
--- a/ftrack_hooks/hook_utils.py
+++ b/ftrack_hooks/hook_utils.py
@@ -51,8 +51,8 @@ def get_components(event, asset_types):
                         data.append({
                             "label": label,
                             "value": {
-                                'name': c.getName(),
-                                'filename': get_file_for_component(c)
+                                'name': component.getName(),
+                                'filename': get_file_for_component(component)
                             }
                         })
 


### PR DESCRIPTION
Currently, the lookup for components for tasks during the quicktime hook fails, due to an invalid variable name. This change uses the correct variable name.

To test, open the quicktime hook from a task level.