### PR TITLE
Fix action

### DIFF
--- a/ftrack_hooks/action.py
+++ b/ftrack_hooks/action.py
@@ -1,5 +1,6 @@
 # :coding: utf-8
 import logging
+import getpass
 
 
 class BaseAction(object):
@@ -43,7 +44,10 @@ class BaseAction(object):
         '''Registers the action, subscribing the the discover and launch
         topics.'''
         self._session.event_hub.subscribe(
-            'topic=ftrack.action.discover', self._discover
+            'topic=ftrack.action.discover and source.user.username={0}'.format(
+                getpass.getuser()
+            ),
+            self._discover
         )
 
         self._session.event_hub.subscribe(


### PR DESCRIPTION
**Motivation**

Actions are getting discovered multiple times across ftrack-connect instances. This happens because the discover method was not filtering on the username, which is standard practice on old API actions;

https://github.com/tokejepsen/ftrack-hooks/blob/a3eba3bd65200fde0d78626f588b6f7f260696dd/djv_plugin/resource/hook/djvview.py#L36