### PR TITLE
DJV: Support new api search plugin.

### DIFF
--- a/djv_plugin/resource/hook/djvview.py
+++ b/djv_plugin/resource/hook/djvview.py
@@ -8,6 +8,8 @@ import re
 from operator import itemgetter
 
 import ftrack
+import ftrack_api
+from ftrack_connect.session import get_shared_session
 import ftrack_connect.application
 
 
@@ -171,6 +173,14 @@ class DJVViewAction(object):
         try:
             ftrack.EVENT_HUB.publish(
                 ftrack.Event(
+                    topic='djvview.launch',
+                    data=data
+                ),
+                synchronous=True
+            )
+            session = get_shared_session()
+            session.event_hub.publish(
+                ftrack_api.event.base.Event(
                     topic='djvview.launch',
                     data=data
                 ),


### PR DESCRIPTION
**Motivation**

Support new API event plugins when searching.

This is so the plugin doesn't determine what API to use for the search plugins.